### PR TITLE
Fixes for 8.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.vo
+*.vok
+*.vos
 *.glob
 *.v.d
 *.cmi
@@ -16,3 +18,5 @@ Makefile.opam.coq
 deps.dot
 deps.pdf
 .coqdeps.d
+*.Makefile.coq.d
+*.lia.cache

--- a/theories/Programming/Extras.v
+++ b/theories/Programming/Extras.v
@@ -13,6 +13,8 @@ Open Scope monad_scope.
 Set Implicit Arguments.
 Set Maximal Implicit Insertion.
 
+Import ListNotations.
+
 Module FunNotation.
 
   Notation "f $ x" := (f x)


### PR DESCRIPTION
I branched out of the f81baf992e commit which is used as submodule in certicoq and made two slight updates to work under `8.12`. Should I better rebase on the top of your `fix-8.11` branch? Or do we want to change to a branch at `coq-community/coq-ext-lib` to ensure opam package compatibility?